### PR TITLE
feat: support hotlinking

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,16 @@
     "watch": "watch 'npm run build' src/"
   },
   "browserify": {
-    "transform": [ "browserify-shim" ]
+    "transform": [
+      "browserify-shim"
+    ]
   },
   "browserify-shim": {
     "angular": "global:angular"
   },
   "dependencies": {
     "angular": "^1.3.15",
+    "npm-package-arg": "^4.1.0",
     "semver": "^4.3.1"
   },
   "devDependencies": {

--- a/src/entry.js
+++ b/src/entry.js
@@ -1,39 +1,88 @@
 var angular = require('angular');
-var app = angular.module('SemverApp', []);
 var semver = require('semver');
+var npa = require('npm-package-arg');
+var app = angular.module('SemverApp', [])
+    .config(['$locationProvider', function($locationProvider) {
+      $locationProvider.html5Mode(true).hashPrefix('!');
+    }]);
 
-app.controller('VersionCtrl', function($scope, $http) {
+app.controller('VersionCtrl', function($scope, $http, $location) {
   var versions;
-  $scope.package = 'lodash';
+  var defaults = {
+    name: 'lodash',
+    rawSpec: '1.x',
+  };
+
+  var pkg = $location.hash();
+  if (pkg) {
+    defaults = npa(pkg);
+  }
+
+  $scope.package = defaults.name;
+  $scope.loading = true;
+
+  $scope.$on('$locationChangeSuccess', function () {
+    var hash = $location.hash();
+    if (!hash) {
+      return;
+    }
+
+    var prevName = $scope.package;
+
+    var pkg = npa(hash);
+    $scope.range = pkg.rawSpec;
+    $scope.package = pkg.name;
+    if (!$scope.loading) {
+      if (prevName !== pkg.name) {
+        $scope.getVersions();
+      } else {
+        $scope.renderVersions();
+      }
+    }
+  });
+
+  $scope.checkVersions = function() {
+    $location.hash($scope.package + '@' + $scope.range).replace();
+  };
+
+  $scope.fail = function () {
+    $scope.loading = false;
+    console.log('Sorry, could not load data.');
+  };
 
   $scope.getVersions = function() {
-    $scope.loading = true;
+    $scope.loading = true; // always show that spinner
+    $scope.versions = [];
     $http.get('http://npm-registry-cors-proxy.herokuapp.com/' + $scope.package)
-      .success(function(data, status, headers, config) {
+      .success(function(data) {
+        if (!data.versions) {
+          return $scope.fail();
+        }
+
         versions = Object.keys(data.versions);
 
-        $scope.range = '1.x'
+        $scope.range = defaults.rawSpec;
         $scope.versions = versions.map(function(v) {
           return {
-            "version": v
-          }
-        })
+            version: v
+          };
+        });
 
-        $scope.checkVersions = function() {
+        $scope.renderVersions = function () {
           for (var i=0, len=versions.length; i<len; i++) {
             $scope.versions[i].satisfies = semver.satisfies($scope.versions[i].version, $scope.range);
           }
+        };
+
+        if ($scope.loading) { // only happens on complete package reload
+          $scope.checkVersions();
         }
 
-        $scope.checkVersions();
+        $scope.renderVersions();
         $scope.loading = false;
       })
-      .error(function(data, status, headers, config) {
-        $scope.loading = false;
-
-        console.log('Sorry, could not load data.')
-      });
-  }
+      .error($scope.fail);
+  };
 
   $scope.getVersions();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="styles.css">
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
     <meta name="viewport" content="width=device-width,minimum-scale=1.0,initial-scale=1,user-scalable=yes">
+    <base href="/">
   </head>
   <body ng-app="SemverApp">
     <h1>npm semver calculator</h1>
@@ -38,7 +39,7 @@
             <h4>examples:</h4>
             <ul>
               <li>
-                <code>^2.2.1</code>
+                <code><a href="#lodash@^2.2.1">^2.2.1</a></code>
               </li>
             </ul>
           </div>
@@ -51,7 +52,7 @@
             <h4>examples:</h4>
             <ul>
               <li>
-                <code>~2.2.0</code>
+                <code><a href="#lodash@~2.2.0">~2.2.0</a></code>
               </li>
             </ul>
           </div>
@@ -64,10 +65,10 @@
             <h4>examples:</h4>
             <ul>
               <li>
-                <code>>2.1</code>
+                <code><a href="#lodash@>2.1">>2.1</a></code>
               </li>
               <li>
-                <code>1.0.0 - 1.2.0</code>
+                <code><a href="#lodash@1.0.0 - 1.2.0">1.0.0 - 1.2.0</a></code>
               </li>
             </ul>
           </div>
@@ -81,7 +82,7 @@
             <h4>examples:</h4>
             <ul>
               <li>
-                <code>1.0.0-rc.1</code>
+                <code><a href="#lodash@1.0.0-rc.1">1.0.0-rc.1</a></code>
               </li>
             </ul>
           </div>
@@ -95,10 +96,10 @@
             <h4>examples:</h4>
             <ul>
               <li>
-                <code>>1.0.0-alpha</code>
+                <code><a href="#lodash@>1.0.0-alpha">>1.0.0-alpha</a></code>
               </li>
               <li>
-                <code>>=1.0.0-rc.0 <1.0.1</code>
+                <code><a href="#lodash@>=1.0.0-rc.0 <1.0.1">>=1.0.0-rc.0 <1.0.1</a></code>
               </li>
             </ul>
           </div>
@@ -111,7 +112,7 @@
             <h4>examples:</h4>
             <ul>
               <li>
-                <code>^2 <2.2 || > 2.3</code>
+                <code><a href="#lodash@^2 <2.2 || > 2.3">^2 <2.2 || > 2.3</a></code>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
I'm not sure how much this tool is used, but I use it a lot to validate semver ranges and quick tests, but the thing is lacks is the ability to share a link to highlight visually what a semver range does.

So this PR adds that feature.

In a nutshell (sorry the video is so small!):

![semver-npm](https://cloud.githubusercontent.com/assets/13700/13007214/9b9b8f9a-d186-11e5-8469-2b20e3ea90c5.gif)

Features:

- Use history API (via Angular `$location`)
- Location bar can be used to change and link directly to a semver test, i.e. `#npm@1.x`
- Examples turned into clickable links
- When user changes the package name or range, it updates the hash in the location bar
- Also tweaked code to show loader when requesting fresh package