### PR TITLE
Update to use registry.npmjs.cf

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -8,7 +8,7 @@ app.controller('VersionCtrl', function($scope, $http) {
 
   $scope.getVersions = function() {
     $scope.loading = true;
-    $http.get('http://npm-registry-cors-proxy.herokuapp.com/' + $scope.package)
+    $http.get('https://registry.npmjs.cf/' + $scope.package)
       .success(function(data, status, headers, config) {
         versions = Object.keys(data.versions);
 


### PR DESCRIPTION
The previous CORS proxy hosted on the free Heroku tier is not maintained (as per https://github.com/npm/semver.npmjs.com/issues/5).

Following the breadcrumbs, there is support for adding CORS to the official npm API (https://github.com/npm/public-api/issues/15),
but, it isn't likely to happen any time soon.

Thankfully, there exists an npm mirror hosted by @terinjokes (an npm member) which supports both CORS and HTTPS.